### PR TITLE
Modify upgrade logic. Add convenience testing.

### DIFF
--- a/Assets/Scenes/StartScene.unity
+++ b/Assets/Scenes/StartScene.unity
@@ -1372,6 +1372,7 @@ MonoBehaviour:
   - {fileID: 11400000, guid: cef3843dafdd78c4a851bb5d5a074139, type: 2}
   - {fileID: 11400000, guid: a65121a21f12eae4c9022d3e45f4f607, type: 2}
   - {fileID: 11400000, guid: 4230748aa5087be458bae01ff12044d7, type: 2}
+  - {fileID: 11400000, guid: e3012c75ffcd62f4a83c52bd5f4e352c, type: 2}
   cardPrefab: {fileID: 6877663276512389695, guid: 2e0b677c5fa0bcf4fa48c32240e415e5, type: 3}
   cardContainer: {fileID: 1872827613}
   confirmButton: {fileID: 1041646824}
@@ -2792,8 +2793,6 @@ MonoBehaviour:
   targetLayer:
     serializedVersion: 2
     m_Bits: 0
-  tier: 0
-  maxTier: 5
   upgradeData: {fileID: 11400000, guid: cef3843dafdd78c4a851bb5d5a074139, type: 2}
   attackRadius: 3
   attackAngle: 90
@@ -3244,7 +3243,7 @@ GameObject:
   m_Icon: {fileID: 0}
   m_NavMeshLayer: 0
   m_StaticEditorFlags: 0
-  m_IsActive: 1
+  m_IsActive: 0
 --- !u!4 &2093713206
 Transform:
   m_ObjectHideFlags: 0
@@ -3277,8 +3276,6 @@ MonoBehaviour:
   targetLayer:
     serializedVersion: 2
     m_Bits: 0
-  tier: 0
-  maxTier: 5
   upgradeData: {fileID: 11400000, guid: a65121a21f12eae4c9022d3e45f4f607, type: 2}
   attackRadius: 4
   force: 3

--- a/Assets/Scripts/Attack/AutoAttack.cs
+++ b/Assets/Scripts/Attack/AutoAttack.cs
@@ -6,10 +6,7 @@ public abstract class AutoAttack : Attack
     // DO NOT provide an implementation for Update(), game will autocall Attack's implementation
 
     // Player functionality
-    public int tier = 0; // Attacks unlock at base tier of 1, when not unlocked tier = 0
-    public int maxTier = 5;
     [SerializeField] private Upgrade upgradeData;
-
     protected override bool TargetInRange()
     {
         return true;
@@ -17,11 +14,6 @@ public abstract class AutoAttack : Attack
 
     public virtual void UpgradeAttack()
     {
-        tier++;
-        if (tier >= maxTier && upgradeData != null)
-        {
-            upgradeData.weight = 0f; // Disable the upgrade option from appearing again
-        }
     }
 
 }

--- a/Assets/Scripts/Editor.meta
+++ b/Assets/Scripts/Editor.meta
@@ -1,0 +1,8 @@
+fileFormatVersion: 2
+guid: 9d7a825801f8f4843bf3440d1d07ae95
+folderAsset: yes
+DefaultImporter:
+  externalObjects: {}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/Scripts/Editor/UpgradeResetOnPlay.cs
+++ b/Assets/Scripts/Editor/UpgradeResetOnPlay.cs
@@ -1,0 +1,49 @@
+using UnityEditor;
+using UnityEditor.Callbacks;
+using UnityEngine;
+
+// TESTING script -- make my life easier by allowing repeated test runs
+
+// This script must be placed in Assets/Editor to Unity treats it as an editor-only script
+// It will only run in the Unity editor
+
+// purpose of this script: resets all upgrades (weight and applyCount) whenever we enter/exit play mode
+// Otherwise in the Unity editor the data of ScriptableObjects persist across exitting and entering
+// play mode.
+
+// This is not required for the actual game build
+// UpgradeResetOnPlay is only needed to manually reset the ScriptableObject state when you 
+// hit Play in the Unity Editor, because ScriptableObjects persist their state between Play Mode
+// sessions in the editor. That persistence does not happen in a game build -- each run starts fresh.
+// For actual game build the method GameManager.ResetRun() should already do its job properly.
+
+[InitializeOnLoad]
+public static class UpgradeResetOnPlay
+{
+    static UpgradeResetOnPlay()
+    {
+        EditorApplication.playModeStateChanged += ResetUpgradesOnEnterPlayMode;
+    }
+
+    private static void ResetUpgradesOnEnterPlayMode(PlayModeStateChange state)
+    {
+        if (state == PlayModeStateChange.EnteredPlayMode || state == PlayModeStateChange.ExitingPlayMode)
+        {
+            string[] upgradeGuids = AssetDatabase.FindAssets("t:Upgrade", new[] { "Assets/Upgrades" });
+            foreach (string guid in upgradeGuids)
+            {
+                string path = AssetDatabase.GUIDToAssetPath(guid);
+                Upgrade upgrade = AssetDatabase.LoadAssetAtPath<Upgrade>(path);
+
+                if (upgrade != null)
+                {
+                    upgrade.ResetUpgrade();
+                    EditorUtility.SetDirty(upgrade); // Marks object as modified
+                }
+            }
+
+            Debug.Log("All upgrades in Assets/Upgrades have been reset.");
+        }
+    }
+}
+

--- a/Assets/Scripts/Editor/UpgradeResetOnPlay.cs.meta
+++ b/Assets/Scripts/Editor/UpgradeResetOnPlay.cs.meta
@@ -1,0 +1,2 @@
+fileFormatVersion: 2
+guid: 13f0538a96ec77f498fc01b98d9e074b

--- a/Assets/Scripts/GameRoot/GameManager.cs
+++ b/Assets/Scripts/GameRoot/GameManager.cs
@@ -135,6 +135,7 @@ public class GameManager : MonoBehaviour
         // Reset upgrade state
         if (upgradeManager != null)
         {
+            upgradeManager.ResetAllUpgrades(); // reset all weights and applyCounts of upgrades
             Destroy(upgradeManager.gameObject); // to reset the upgrade manager 
         }
 

--- a/Assets/Scripts/GameRoot/StageManager.cs
+++ b/Assets/Scripts/GameRoot/StageManager.cs
@@ -21,7 +21,7 @@ public class StageManager : MonoBehaviour
     private int currentStageIndex;
     [SerializeField] private GameObject teleporterPrefab;
     private GameObject currentTeleporter;
-    [SerializeField] private GameObject player;
+    public GameObject player;
 
     void Start()
     {

--- a/Assets/Scripts/GameRoot/UpgradeManager.cs
+++ b/Assets/Scripts/GameRoot/UpgradeManager.cs
@@ -5,6 +5,7 @@ using System;
 using System.Collections.Generic;
 using TMPro;
 using System.Data;
+using UnityEditor.Rendering.Universal;
 
 // Upon every level up of the player, the game freezes and 3 upgrade cards appear on the screen (UI)
 // the player will pick 1 of the 3 upgrades
@@ -21,8 +22,7 @@ public class UpgradeManager : MonoBehaviour
     private Action onUpgradeComplete; // Action is a type that represents a method that returns void
     private Upgrade selectedUpgrade;
     private List<GameObject> activeCards = new(); // the 3 upgrade cards that player can pick from
-
-    public static UpgradeManager Instance;
+    public static UpgradeManager Instance; // singleton
 
     void Awake()
     {
@@ -31,7 +31,7 @@ public class UpgradeManager : MonoBehaviour
             Instance = this;
             DontDestroyOnLoad(gameObject);
         }
-        else 
+        else
         {
             Destroy(gameObject);
         }
@@ -59,7 +59,7 @@ public class UpgradeManager : MonoBehaviour
         foreach (Upgrade upgrade in options)
         {
             GameObject card = Instantiate(cardPrefab, cardContainer); // instantiates a card gameobject 
-                // based on the prefab as a child of cardContainer
+                                                                      // based on the prefab as a child of cardContainer
             SetupCardUI(card, upgrade);
             activeCards.Add(card);
         }
@@ -69,13 +69,17 @@ public class UpgradeManager : MonoBehaviour
     // Weighted selection of upgrade options
     private List<Upgrade> GetRandomUpgrades(int count)
     {
-        List<Upgrade> pool = new(allUpgrades);
+        List<Upgrade> pool = new();
         List<Upgrade> selected = new();
-
         float totalWeight = 0f;
-        foreach (Upgrade upgrade in pool)
+
+        foreach (Upgrade upgrade in allUpgrades)
         {
-            totalWeight += upgrade.weight; // weight >= 0 for all upgrades
+            if (upgrade.Selectable && upgrade.weight > 0f)
+            {
+                pool.Add(upgrade);
+                totalWeight += upgrade.weight; // weight >= 0 for all upgrades
+            }
         }
 
         if (totalWeight <= 0f)
@@ -88,6 +92,7 @@ public class UpgradeManager : MonoBehaviour
             // each iteration of while loop adds 1 card to selected
             float randomThreshold = UnityEngine.Random.Range(0, totalWeight);
             float cumulative = 0f;
+            bool found = false;
             for (int i = 0; i < pool.Count; i++)
             {
                 cumulative += pool[i].weight;
@@ -96,8 +101,17 @@ public class UpgradeManager : MonoBehaviour
                     selected.Add(pool[i]);
                     totalWeight -= pool[i].weight;
                     pool.RemoveAt(i);
+                    found = true;
                     break;
                 }
+            }
+            // Fallback: if not found due to precision (rounding), select last upgrade
+            if (!found && pool.Count > 0)
+            {
+                int lastIndex = pool.Count - 1;
+                selected.Add(pool[lastIndex]);
+                totalWeight -= pool[lastIndex].weight;
+                pool.RemoveAt(lastIndex);
             }
         }
         return selected;
@@ -157,6 +171,15 @@ public class UpgradeManager : MonoBehaviour
         if (player != null)
         {
             ConfirmSelection(player);
+        }
+    }
+
+    // Called when we reset after each game run
+    public void ResetAllUpgrades()
+    {
+        foreach (Upgrade upgrade in allUpgrades)
+        {
+            upgrade.ResetUpgrade();
         }
     }
 

--- a/Assets/Scripts/PlayerScripts/PlayerScript.cs
+++ b/Assets/Scripts/PlayerScripts/PlayerScript.cs
@@ -19,9 +19,8 @@ public class PlayerScript : Entity
     private Dictionary<string, AutoAttack> allAttacks = new(); // keyed on attack scripts name
     private List<AutoAttack> activeAttacks = new();
     private bool hasTeleporter = false;
-
     [SerializeField] private XpScript xpScript;
-    [SerializeField] private float xpPickUpRadius = 2.0f;
+    public float xpPickUpRadius = 2.0f;
     [SerializeField] private LayerMask xpLayer;
 
     private void Awake()
@@ -53,11 +52,10 @@ public class PlayerScript : Entity
         foreach (AutoAttack attack in attacks)
         {
             attack.gameObject.SetActive(false);  // disable everything first
-            attack.tier = 0;
             allAttacks[attack.GetType().Name] = attack;  // use class name as key
         }
 
-        // Enable starting attack
+        // Enable starting attack, set starting attack to applyCount 1 in inspector
         UnlockOrUpgradeAttack("AOEPunch");
     }
 
@@ -151,7 +149,7 @@ public class PlayerScript : Entity
     {
         if (allAttacks.TryGetValue(attackName, out AutoAttack attack))
         {
-            if (!attack.gameObject.activeSelf)
+            if (!attack.gameObject.activeSelf) // if gameobject is disabled, enable it
             {
                 attack.gameObject.SetActive(true);
                 activeAttacks.Add(attack);

--- a/Assets/Scripts/SwitchScene.cs
+++ b/Assets/Scripts/SwitchScene.cs
@@ -125,6 +125,12 @@ public class SwitchScene : MonoBehaviour
             return;
         }
 
+        // --- StageManager assignment ---
+        if (GameManager.Instance.stageManager != null)
+        {
+            GameManager.Instance.stageManager.player = player.gameObject;
+        }
+        
         // --- PlayerUIManager assignments ---
         if (GameManager.Instance.playerUI != null)
         {

--- a/Assets/Scripts/Upgrades/MovementSpeed.cs
+++ b/Assets/Scripts/Upgrades/MovementSpeed.cs
@@ -1,9 +1,10 @@
 using UnityEngine;
 
 [CreateAssetMenu(fileName = "IncreaseMovementSpeed", menuName = "Upgrades/Movement Speed")]
+// set maxApplyCount = 5;
 public class MovementSpeed : Upgrade
 {
-    [SerializeField] private float speedIncrease = 1f; 
+    [SerializeField] private float speedIncrease = 1f;
 
     public override void ApplyUpgrade(PlayerScript player)
     {

--- a/Assets/Scripts/Upgrades/PickupXPRadius.cs
+++ b/Assets/Scripts/Upgrades/PickupXPRadius.cs
@@ -1,0 +1,14 @@
+using UnityEngine;
+
+[CreateAssetMenu(fileName = "PickupXPRadiusUpgrade", menuName = "Upgrades/Pickup XP Radius")]
+// set maxApplyCount = 5
+public class PickupXPRadius : Upgrade
+{
+    float pickupRadiusIncrement = 1f;
+    public override void ApplyUpgrade(PlayerScript player)
+    {
+        base.ApplyUpgrade(player);
+        player.xpPickUpRadius += pickupRadiusIncrement;
+    }
+
+}

--- a/Assets/Scripts/Upgrades/PickupXPRadius.cs.meta
+++ b/Assets/Scripts/Upgrades/PickupXPRadius.cs.meta
@@ -1,0 +1,2 @@
+fileFormatVersion: 2
+guid: 1d31aaa6f9abb0a4c85486d80e8b9a6e

--- a/Assets/Scripts/Upgrades/Upgrade.cs
+++ b/Assets/Scripts/Upgrades/Upgrade.cs
@@ -8,12 +8,34 @@ public abstract class Upgrade : ScriptableObject
     public string upgradeName;
     public string description;
     public Sprite icon;
-    public float weight = 1f; // default likelihood weight, minimum value: set to 0 (do not set)
-    // we use weight to set the relative likelihoods of Upgrade assets being displayed to players
+    public float weight = 1f; // default likelihood weight = 1, weight >= 0 for all upgrades 
+        // weight is set in inspector, and never mutated at runtime
+
+    [SerializeField] private int applyCount = 0; // number of times this upgrade has been applied
+    [SerializeField] private int maxApplyCount = -1; // -1 means upgrade can be applied unlimited times 
+    private bool selectable = true; // indicates if this upgrade can be offered to player at level up
+
+    public bool isSelectable()
+    {
+        if (maxApplyCount == -1) return true;
+        return applyCount < maxApplyCount;
+    }
 
     // Called when player selects the upgrade
     public virtual void ApplyUpgrade(PlayerScript player)
     {
         Debug.Log($"Applied {upgradeName}");
+        applyCount++;
+        selectable = isSelectable();
     }
+
+    // Called at the end of each run when we reset 
+    public void ResetUpgrade()
+    {
+        applyCount = 0;
+        selectable = true;
+    }
+
+    // Expose selectable status (used by UpgradeManager to filter)
+    public bool Selectable => selectable;
 }

--- a/Assets/Upgrades/Attack Upgrades/AOEPunchUpgrade.asset
+++ b/Assets/Upgrades/Attack Upgrades/AOEPunchUpgrade.asset
@@ -16,3 +16,5 @@ MonoBehaviour:
   description: 'Upgrade attack: AOE Punch'
   icon: {fileID: -9182177788924653191, guid: a4970f398ccc36844b4507f749997be2, type: 3}
   weight: 1
+  applyCount: 1
+  maxApplyCount: 5

--- a/Assets/Upgrades/Attack Upgrades/RepulsiveField Upgrade.asset
+++ b/Assets/Upgrades/Attack Upgrades/RepulsiveField Upgrade.asset
@@ -16,3 +16,5 @@ MonoBehaviour:
   description: 'Upgrade attack: Repulsive Field'
   icon: {fileID: -9182177788924653191, guid: a4970f398ccc36844b4507f749997be2, type: 3}
   weight: 1
+  applyCount: 0
+  maxApplyCount: 5

--- a/Assets/Upgrades/Stats Upgrades/IncreaseMovementSpeed.asset
+++ b/Assets/Upgrades/Stats Upgrades/IncreaseMovementSpeed.asset
@@ -16,4 +16,6 @@ MonoBehaviour:
   description: Movement Speed +1
   icon: {fileID: 21300000, guid: b6588b20aa564ec41b77e43758ad3fc7, type: 3}
   weight: 1
+  applyCount: 0
+  maxApplyCount: 5
   speedIncrease: 1

--- a/Assets/Upgrades/Stats Upgrades/Large ATK Upgrade.asset
+++ b/Assets/Upgrades/Stats Upgrades/Large ATK Upgrade.asset
@@ -16,4 +16,6 @@ MonoBehaviour:
   description: ATK +20
   icon: {fileID: 21300000, guid: c2c7aefc7e6ee394eb1cbebd90ea39c1, type: 3}
   weight: 0.5
+  applyCount: 0
+  maxApplyCount: -1
   extraATK: 20

--- a/Assets/Upgrades/Stats Upgrades/Large Max Health Upgrade.asset
+++ b/Assets/Upgrades/Stats Upgrades/Large Max Health Upgrade.asset
@@ -16,4 +16,6 @@ MonoBehaviour:
   description: MaxHP +200, HP% is maintained
   icon: {fileID: 21300000, guid: e43e14395464cc445bdf7112105d2e6a, type: 3}
   weight: 0.5
+  applyCount: 0
+  maxApplyCount: -1
   extraMaxHP: 200

--- a/Assets/Upgrades/Stats Upgrades/Large RestoreLostHealth.asset
+++ b/Assets/Upgrades/Stats Upgrades/Large RestoreLostHealth.asset
@@ -16,4 +16,6 @@ MonoBehaviour:
   description: +100% Lost Health, Full Recovery!
   icon: {fileID: 21300000, guid: 0794091e4be13b046814fd4a4db266be, type: 3}
   weight: 0.5
+  applyCount: 0
+  maxApplyCount: -1
   percentageRestored: 1

--- a/Assets/Upgrades/Stats Upgrades/Medium Max Health Upgrade.asset
+++ b/Assets/Upgrades/Stats Upgrades/Medium Max Health Upgrade.asset
@@ -16,4 +16,6 @@ MonoBehaviour:
   description: MaxHP +100, HP% is maintained
   icon: {fileID: 21300000, guid: e43e14395464cc445bdf7112105d2e6a, type: 3}
   weight: 0.5
+  applyCount: 0
+  maxApplyCount: -1
   extraMaxHP: 100

--- a/Assets/Upgrades/Stats Upgrades/Medium RestoreLostHealth.asset
+++ b/Assets/Upgrades/Stats Upgrades/Medium RestoreLostHealth.asset
@@ -16,4 +16,6 @@ MonoBehaviour:
   description: +50% Lost HP
   icon: {fileID: 21300000, guid: 0794091e4be13b046814fd4a4db266be, type: 3}
   weight: 0.5
+  applyCount: 0
+  maxApplyCount: -1
   percentageRestored: 0.5

--- a/Assets/Upgrades/Stats Upgrades/PickupXPRadiusUpgrade.asset
+++ b/Assets/Upgrades/Stats Upgrades/PickupXPRadiusUpgrade.asset
@@ -9,13 +9,12 @@ MonoBehaviour:
   m_GameObject: {fileID: 0}
   m_Enabled: 1
   m_EditorHideFlags: 0
-  m_Script: {fileID: 11500000, guid: ac364043ed8a2b643871a3803b2e86be, type: 3}
-  m_Name: Medium ATK Upgrade
+  m_Script: {fileID: 11500000, guid: 1d31aaa6f9abb0a4c85486d80e8b9a6e, type: 3}
+  m_Name: PickupXPRadiusUpgrade
   m_EditorClassIdentifier: 
-  upgradeName: Medium ATK Upgrade
-  description: ATK +10
-  icon: {fileID: 21300000, guid: c2c7aefc7e6ee394eb1cbebd90ea39c1, type: 3}
-  weight: 0.5
+  upgradeName: Increase XP Pickup Radius
+  description: XP pickup radius +1
+  icon: {fileID: 0}
+  weight: 1
   applyCount: 0
-  maxApplyCount: -1
-  extraATK: 10
+  maxApplyCount: 5

--- a/Assets/Upgrades/Stats Upgrades/PickupXPRadiusUpgrade.asset.meta
+++ b/Assets/Upgrades/Stats Upgrades/PickupXPRadiusUpgrade.asset.meta
@@ -1,0 +1,8 @@
+fileFormatVersion: 2
+guid: e3012c75ffcd62f4a83c52bd5f4e352c
+NativeFormatImporter:
+  externalObjects: {}
+  mainObjectFileID: 11400000
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/Upgrades/Stats Upgrades/Small ATK Upgrade.asset
+++ b/Assets/Upgrades/Stats Upgrades/Small ATK Upgrade.asset
@@ -16,4 +16,6 @@ MonoBehaviour:
   description: ATK +5
   icon: {fileID: 21300000, guid: c2c7aefc7e6ee394eb1cbebd90ea39c1, type: 3}
   weight: 1
+  applyCount: 0
+  maxApplyCount: -1
   extraATK: 5

--- a/Assets/Upgrades/Stats Upgrades/Small Max Health Upgrade.asset
+++ b/Assets/Upgrades/Stats Upgrades/Small Max Health Upgrade.asset
@@ -16,4 +16,6 @@ MonoBehaviour:
   description: MaxHP +50, HP% is maintained
   icon: {fileID: 21300000, guid: e43e14395464cc445bdf7112105d2e6a, type: 3}
   weight: 1
+  applyCount: 0
+  maxApplyCount: -1
   extraMaxHP: 50

--- a/Assets/Upgrades/Stats Upgrades/Small RestoreLostHealth.asset
+++ b/Assets/Upgrades/Stats Upgrades/Small RestoreLostHealth.asset
@@ -16,4 +16,6 @@ MonoBehaviour:
   description: +25% Lost HP
   icon: {fileID: 21300000, guid: 0794091e4be13b046814fd4a4db266be, type: 3}
   weight: 1
+  applyCount: 0
+  maxApplyCount: -1
   percentageRestored: 0.25


### PR DESCRIPTION
Switch to using a boolean field instead of setting weight = 0 for whether upgrade cards can be displayed on level up.

TESTING: Added purely editor script UpgradeResetOnPlay to facilitate testing when we repeatedly enter and exit play mode to reset ScriptableObjects (upgrades).

Added upgrade PickupXPRadius -- has a max applyCount of 5. Modified IncreaseMovementSpeed to have a max applyCount of 5. Modified the existing attack upgrades AOEPunch and RepulsiveField to use the same applyCount logic.

Minor fix to reference grabbing on StartManager.

Now the chain of methods called when applying an upgrade is :
1. UpgradeManager.ConfirmSelection
2. upgrade.ApplyUpgrade (automatically keeps track of applyCount) --- For player attack upgrades:
3. PlayerScript.UnlockOrUpgradeAttack
4. attack.UpgradeAttack --> need to implement for each concrete autoattack